### PR TITLE
Make sure person object type themselves as person when created

### DIFF
--- a/app/src/main/java/com/berniesanders/fieldthebern/models/Person.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/models/Person.java
@@ -303,10 +303,12 @@ public class Person extends CanvassData implements Parcelable {
     }
 
     public Person() {
+        type = TYPE;
     }
 
     protected Person(Parcel in) {
         super(in);
+        type = TYPE;
         this.id = (Integer) in.readValue(Integer.class.getClassLoader());
         this.type = in.readString();
         this.attributes = in.readParcelable(Attributes.class.getClassLoader());


### PR DESCRIPTION
Fixes #220 a bug where visits would not include the people because Android wasn't typing the people object it was sending to the API.
