### PR TITLE
Remove party mapping hacks

### DIFF
--- a/app/src/main/java/com/berniesanders/fieldthebern/media/PartyIcon.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/media/PartyIcon.java
@@ -21,22 +21,16 @@ public class PartyIcon {
 
         switch (party) {
             case Party.DEMOCRAT:
-            case Party.DEMOCRAT_AFFILIATION :
                 return R.drawable.ic_democrat;
             case Party.INDEPENDENT:
-            case Party.INDEPENDENT_AFFILIATION :
                 return R.drawable.ic_independent;
             case Party.REPUBLICAN:
-            case Party.REPUBLICAN_AFFILIATION :
                 return R.drawable.ic_republican;
             case Party.UNAFFILIATED:
-            case Party.UNAFFILIATED_AFFILIATION :
                 return R.drawable.ic_other;
             case Party.UNDECLARED:
-            case Party.UNDECLARED_AFFILIATION :
                 return R.drawable.ic_undeclared;
             case Party.UNKNOWN:
-            case Party.UNKNOWN_AFFILIATION :
                 return R.drawable.ic_undeclared;
             default:
                 Timber.e("cant find PartyIcon for "+party);

--- a/app/src/main/java/com/berniesanders/fieldthebern/models/Party.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/models/Party.java
@@ -15,8 +15,10 @@ import java.lang.annotation.RetentionPolicy;
 public class Party {
 
     // party_affiliation:
-    // <'Unknown'|'Unaffiliated'|'Undeclared'|
-    // 'Democrat'|'Republican'|'Independent'>,
+    // <'unknown_affiliation'|'unaffiliated_affiliation'
+    // |'undeclared_affiliation'|'democrat_affiliation'
+    // |'republican_affiliation'|'independent_affiliation'
+    // |'other_affiliation'>,
     @StringDef({
             UNKNOWN,
             UNAFFILIATED,
@@ -24,12 +26,7 @@ public class Party {
             DEMOCRAT,
             REPUBLICAN,
             INDEPENDENT,
-            UNKNOWN_AFFILIATION,
-            UNAFFILIATED_AFFILIATION,
-            UNDECLARED_AFFILIATION,
-            DEMOCRAT_AFFILIATION,
-            REPUBLICAN_AFFILIATION,
-            INDEPENDENT_AFFILIATION,
+            OTHER
             })
 
     @Retention(RetentionPolicy.SOURCE)
@@ -38,22 +35,12 @@ public class Party {
     public @interface Affiliation{}
 
     //Api input
-    public static final String UNKNOWN = "Unknown";
-    public static final String UNAFFILIATED = "Unaffiliated";
-    public static final String UNDECLARED = "Undeclared";
-    public static final String DEMOCRAT = "Democrat";
-    public static final String REPUBLICAN = "Republican";
-    public static final String INDEPENDENT = "Independent";
-
-
-    //fixme API apparently spits this out instead of the same format it takes above as input
-    //fixme see https://github.com/Bernie-2016/fieldthebern-android/issues/187
-    //fixme work-around until fixed by API
-    public static final String UNKNOWN_AFFILIATION          = "unknown_affiliation";
-    public static final String UNAFFILIATED_AFFILIATION     = "unaffiliated_affiliation";
-    public static final String UNDECLARED_AFFILIATION       = "undeclared_affiliation";
-    public static final String DEMOCRAT_AFFILIATION         = "democrat_affiliation";
-    public static final String REPUBLICAN_AFFILIATION       = "republican_affiliation";
-    public static final String INDEPENDENT_AFFILIATION      = "independent_affiliation";
+    public static final String UNKNOWN          = "unknown_affiliation";
+    public static final String UNAFFILIATED     = "unaffiliated_affiliation";
+    public static final String UNDECLARED       = "undeclared_affiliation";
+    public static final String DEMOCRAT         = "democrat_affiliation";
+    public static final String REPUBLICAN       = "republican_affiliation";
+    public static final String INDEPENDENT      = "independent_affiliation";
+    public static final String OTHER            = "other_affiliation";
 
 }

--- a/app/src/main/java/com/berniesanders/fieldthebern/parsing/PartyEvaluator.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/parsing/PartyEvaluator.java
@@ -16,20 +16,21 @@ public class PartyEvaluator {
     /**
      * Returns the API compatible response that maps to the selected string
      *
-     *   <item>(select party)</item>
-     *   <item>Democrat</item>
-     *   <item>Republican</item>
-     *   <item>Independent</item>
-     *   <item>Undeclared</item>
-     *   <item>Other</item>
-     *
+     *  <item>(select party)</item>
+     *  <item>Democrat</item>
+     *  <item>Republican</item>
+     *  <item>Independent</item>
+     *  <item>Undeclared</item>
+     *  <item>Unaffiliated</item>
+     *  <item>Unknown</item>
+     *  <item>Other</item>
      * TODO better way to do this?!
     */
     @Party.Affiliation
     public static String getParty(String selectedParty, String[] partyArray) {
         if (selectedParty.equals(partyArray[0])) {
             Timber.e("PartyEvaluator.getParty() called but selection is not valid");
-            return Party.UNKNOWN;
+            return Party.UNAFFILIATED;
         } else if (selectedParty.equals(partyArray[1])) {
             return Party.DEMOCRAT;
         } else if (selectedParty.equals(partyArray[2])) {
@@ -40,6 +41,8 @@ public class PartyEvaluator {
             return Party.UNDECLARED;
         } else if (selectedParty.equals(partyArray[5])) {
             return Party.UNKNOWN;
+        } else if (selectedParty.equals(partyArray[6])) {
+            return Party.OTHER;
         } else {
             Timber.e("PartyEvaluator.getParty() called but selection is default?");
             return Party.UNKNOWN;
@@ -62,7 +65,7 @@ public class PartyEvaluator {
     public static String getText(@Party.Affiliation String apiParty, String[] partyArray) {
 
         switch (apiParty) {
-            case Party.UNKNOWN:
+            case Party.UNAFFILIATED:
                 return partyArray[0];
             case Party.DEMOCRAT:
                 return partyArray[1];
@@ -72,45 +75,14 @@ public class PartyEvaluator {
                 return partyArray[3];
             case Party.UNDECLARED:
                 return partyArray[4];
-            case Party.UNAFFILIATED:
+            case Party.UNKNOWN:
                 return partyArray[5];
+            case Party.OTHER:
+                return partyArray[6];
             default:
-                Timber.e("PartyEvaluator.getText() called with unmapped party?");
+                Timber.w("PartyEvaluator.getText() called with unmapped party?");
                 return partyArray[0];
         }
     }
 
-
-    /**
-     * This is a hack to get around an inconsistency in a bug in the API
-     *
-     * The API returns party in the format "democrat_affiliation"
-     * However, the API accepts party in the format "Democrat"
-     *
-     * See: https://github.com/Bernie-2016/fieldthebern-android/issues/219
-     *
-     * Marked as deprecated to make clear this should only be used in very limited situations
-     * @deprecated
-     */
-    @Party.Affiliation
-    public static String mapApiParty(@Party.Affiliation String output) {
-
-        switch (output) {
-            case Party.UNKNOWN_AFFILIATION:
-                return Party.UNKNOWN;
-            case Party.DEMOCRAT_AFFILIATION:
-                return Party.DEMOCRAT;
-            case Party.REPUBLICAN_AFFILIATION:
-                return Party.REPUBLICAN;
-            case Party.INDEPENDENT_AFFILIATION:
-                return Party.INDEPENDENT;
-            case Party.UNDECLARED_AFFILIATION:
-                return Party.UNDECLARED;
-            case Party.UNAFFILIATED_AFFILIATION:
-                return Party.UNAFFILIATED;
-            default:
-                Timber.e("PartyEvaluator.mapApiParty() called with unmapped party? returning original string as a fallback");
-                return output;
-        }
-    }
 }

--- a/app/src/main/java/com/berniesanders/fieldthebern/screens/AddAddressScreen.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/screens/AddAddressScreen.java
@@ -279,18 +279,6 @@ public class AddAddressScreen extends FlowPathBase {
                 Timber.v("singleAddressObserver onNext  response.addresses().get(0) =\n%s", response.addresses().get(0) );
                 address = response.addresses().get(0);
                 address.included(response.included());
-
-                //TODO this is hack because API party values are not the same when outputted as they are input
-                for(CanvassData canvassData : address.included()) {
-                    if (canvassData.type().equals(Person.TYPE)) {
-                        Person person = (Person) canvassData;
-                        if (person.attributes().party() !=null) {
-                            person.attributes().party(
-                                    PartyEvaluator.mapApiParty(
-                                            person.attributes().party()));
-                        }
-                    }
-                }
                 Flow.get(getView()).set(new NewVisitScreen(address));
             }
         };

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
           <item>Republican</item>
           <item>Independent</item>
           <item>Undeclared</item>
+          <item>Unknown</item>
           <item>Other</item>
     </string-array>
 


### PR DESCRIPTION
Still some weirdness with `unaffiliated_affiliation` but mostly fixes #219 by removing the now unneeded hacks around Party constants
