### PR TITLE
Explicitly clear any previous visit when clicking Start Visit from AddAddressScreen

### DIFF
--- a/app/src/main/java/com/berniesanders/fieldthebern/screens/AddAddressScreen.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/screens/AddAddressScreen.java
@@ -293,6 +293,7 @@ public class AddAddressScreen extends FlowPathBase {
                             response.addresses().get(0).attributes().visitedAt())) {
                         address = response.addresses().get(0);
                         address.included(response.included());
+                        visitRepo.clear();
                         Flow.get(getView()).set(new NewVisitScreen(address));
                     } else {
                         ToastService.get(getView()).bern(minTimeNotElapsed, Toast.LENGTH_LONG);


### PR DESCRIPTION
Fixes #299
