### PR TITLE
Remove Unknown option from Canvasser Party List to sync with iOS

### DIFF
--- a/app/src/main/java/com/berniesanders/fieldthebern/views/AddPersonView.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/views/AddPersonView.java
@@ -19,7 +19,6 @@ import com.berniesanders.fieldthebern.parsing.CanvassResponseEvaluator;
 import com.berniesanders.fieldthebern.parsing.PartyEvaluator;
 import com.berniesanders.fieldthebern.screens.AddPersonScreen;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;


### PR DESCRIPTION
This still leaves the full framework for loading Unknown as the default value
