### PR TITLE
Null check callback manager in fb controller onActivityResult

### DIFF
--- a/app/src/main/java/com/berniesanders/fieldthebern/controllers/FacebookController.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/controllers/FacebookController.java
@@ -106,7 +106,9 @@ public class FacebookController extends Presenter<FacebookController.Activity> {
 
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     Timber.v("FacebookController.onActivityResult()");
-    callbackManager.onActivityResult(requestCode, resultCode, data);
+    if (callbackManager!=null) {
+      callbackManager.onActivityResult(requestCode, resultCode, data);
+    }
   }
 
   @Module


### PR DESCRIPTION
fixes #493
The fb controller can be called with activity results not meant for it, so we null check the callback manager