### PR TITLE
Add concise login failure messages

### DIFF
--- a/app/src/main/java/com/berniesanders/fieldthebern/screens/LoginScreen.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/screens/LoginScreen.java
@@ -399,9 +399,10 @@ public class LoginScreen extends FlowPathBase {
           return;
         }
 
-        if (e instanceof HttpException) {
-          ErrorResponse errorResponse = errorResponseParser.parse((HttpException) e);
-          ToastService.get(getView()).bern(errorResponse.getAllDetails());
+        if (e instanceof HttpException && ((HttpException) e).code() == 401) {
+          ToastService.get(getView()).bern(getView().getResources().getString(R.string.err_incorrect_email_pass));
+        } else {
+          ToastService.get(getView()).bern(getView().getResources().getString(R.string.err_login_failed_generic));
         }
         ProgressDialogService.get(getView()).dismiss();
         showPleaseWait = false;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,8 @@
   <string name="err_cant_load_photo">Unable to load photo</string>
   <string name="err_no_visit">Please add or edit a person, or indicate if no one was home, or you were asked to leave</string>
   <string name="err_registration_generic">Error logging in. Please restart and try again or email support at support@fieldthebern.com</string>
+  <string name="err_incorrect_email_pass">Incorrect email or password</string>
+  <string name="err_login_failed_generic">Login failed</string>
   <string name="location_disabled_title">Location disabled</string>
   <string name="location_disabled_message">Please enable your phone\'s location setting (specifically WiFi and network location)</string>
   <string name="profile_saved">Profile saved</string>


### PR DESCRIPTION
Replaces the lengthy existing message. Shows "incorrect email or password"
in the case of a 401 response, and a generic "login failed" otherwise.

Fixes #475.
