### PR TITLE
allow leaderboard score to fit on one line

### DIFF
--- a/app/src/main/java/com/berniesanders/fieldthebern/screens/RankingAdapter.java
+++ b/app/src/main/java/com/berniesanders/fieldthebern/screens/RankingAdapter.java
@@ -39,14 +39,14 @@ public class RankingAdapter extends ArrayAdapter<String> {
   private List<Rankings.Data> datas;
 
   public RankingAdapter(Context context, List<UserData> userDatas, List<Rankings.Data> datas) {
-    super(context, R.layout.screen_profile_row, new String[userDatas.size()]);
+    super(context, R.layout.row_profile, new String[userDatas.size()]);
     this.context = context;
     this.userDatas = userDatas;
     this.datas = datas;
   }
 
   public View getView(int position, View view, ViewGroup viewGroup) {
-    View newView = LayoutInflater.from(context).inflate(R.layout.screen_profile_row, null, true);
+    View newView = LayoutInflater.from(context).inflate(R.layout.row_profile, null, true);
 
     UserAttributes attributes = this.userDatas.get(position).attributes();
     Rankings.Attributes attributes1 = this.datas.get(position).attributes();

--- a/app/src/main/res/layout/row_profile.xml
+++ b/app/src/main/res/layout/row_profile.xml
@@ -23,7 +23,8 @@
 
   <TextView
     android:id="@+id/position"
-    android:layout_width="24dp"
+    android:layout_width="wrap_content"
+    android:ems="4"
     android:layout_height="wrap_content"
     android:layout_alignParentLeft="true"
     android:layout_centerVertical="true"

--- a/app/src/main/res/layout/row_profile.xml
+++ b/app/src/main/res/layout/row_profile.xml
@@ -24,14 +24,14 @@
   <TextView
     android:id="@+id/position"
     android:layout_width="wrap_content"
-    android:ems="4"
+    android:minEms="3"
     android:layout_height="wrap_content"
     android:layout_alignParentLeft="true"
     android:layout_centerVertical="true"
     android:layout_marginRight="8dp"
     android:gravity="right"
     android:textColor="@android:color/white"
-    tools:text="12" />
+    tools:text="1234" />
 
   <ImageView
     android:id="@+id/profile_image"


### PR DESCRIPTION
changed layout name to row_profile for consistency with other list item layouts

set ems to 4 on score textview to guarantee that 4 digits can always safely fit in that space regardless of font (if someone hits a score of 10k, I suppose we'd have to update it again)
